### PR TITLE
Add some more menus to CREATE-PROJECT

### DIFF
--- a/skeleton/<% @var name %>/<% @var name %>.asd
+++ b/skeleton/<% @var name %>/<% @var name %>.asd
@@ -25,7 +25,8 @@
   :author "<% @var author %>"
   :mailto "<% @var email %>"<% @if homepage %>
   :homepage "<% @var homepage %>"<% @endif %><% @if bug-tracker %>
-  :bug-tracker "<% @var bug-tracker %>"<% @endif %>
+  :bug-tracker "<% @var bug-tracker %>"<% @endif %><% @if source-control %>
+  :source-control <% (apply #'format t "(:~A \"~A\")" (getf env :source-control)) %><%  @endif %>
   :license "<% @var license %>"
   :depends-on (<% (format t "~{:~(~A~)~^ ~}" (getf env :depends-on)) %>)
   :components ((:module "<% @var source-dir %>"

--- a/skeleton/<% @var name %>/<% @var name %>.asd
+++ b/skeleton/<% @var name %>/<% @var name %>.asd
@@ -24,6 +24,7 @@
   :version "0.1"
   :author "<% @var author %>"
   :mailto "<% @var email %>"
+  :homepage "<% @var homepage %>"
   :license "<% @var license %>"
   :depends-on (<% (format t "~{:~(~A~)~^ ~}" (getf env :depends-on)) %>)
   :components ((:module "<% @var source-dir %>"

--- a/skeleton/<% @var name %>/<% @var name %>.asd
+++ b/skeleton/<% @var name %>/<% @var name %>.asd
@@ -23,9 +23,9 @@
 (defsystem <% @var name %>
   :version "0.1"
   :author "<% @var author %>"
-  :mailto "<% @var email %>"
-  :homepage "<% @var homepage %>"
-  :bug-tracker "<% @var bug-tacker %>"
+  :mailto "<% @var email %>"<% @if homepage %>
+  :homepage "<% @var homepage %>"<% @endif %><% @if bug-tracker %>
+  :bug-tracker "<% @var bug-tacker %>"<% @endif %>
   :license "<% @var license %>"
   :depends-on (<% (format t "~{:~(~A~)~^ ~}" (getf env :depends-on)) %>)
   :components ((:module "<% @var source-dir %>"

--- a/skeleton/<% @var name %>/<% @var name %>.asd
+++ b/skeleton/<% @var name %>/<% @var name %>.asd
@@ -25,6 +25,7 @@
   :author "<% @var author %>"
   :mailto "<% @var email %>"
   :homepage "<% @var homepage %>"
+  :bug-tracker "<% @var bug-tacker %>"
   :license "<% @var license %>"
   :depends-on (<% (format t "~{:~(~A~)~^ ~}" (getf env :depends-on)) %>)
   :components ((:module "<% @var source-dir %>"

--- a/skeleton/<% @var name %>/<% @var name %>.asd
+++ b/skeleton/<% @var name %>/<% @var name %>.asd
@@ -25,7 +25,7 @@
   :author "<% @var author %>"
   :mailto "<% @var email %>"<% @if homepage %>
   :homepage "<% @var homepage %>"<% @endif %><% @if bug-tracker %>
-  :bug-tracker "<% @var bug-tacker %>"<% @endif %>
+  :bug-tracker "<% @var bug-tracker %>"<% @endif %>
   :license "<% @var license %>"
   :depends-on (<% (format t "~{:~(~A~)~^ ~}" (getf env :depends-on)) %>)
   :components ((:module "<% @var source-dir %>"

--- a/src/create/project-local.lisp
+++ b/src/create/project-local.lisp
@@ -29,7 +29,9 @@ information is required for quicklisp submission, and missing this
 information annoyes Xach because he has to ask you to add that information
 each time.")
   (set-x :homepage
-         "Enter the homepage URL of this library."))
+         "Enter the homepage URL of this library.")
+  (set-x :bug-tracker
+         "Enter URL under which a user can open bugs for this library."))
 
 (defmenu (add-local-dependency :in create-project)
   (q "Enter a name of a library. The input string is converted to a keyword.

--- a/src/create/project-local.lisp
+++ b/src/create/project-local.lisp
@@ -27,7 +27,9 @@ subfolder, asdf system name and the package name.")
          "Enter the short description of this library. Description
 information is required for quicklisp submission, and missing this
 information annoyes Xach because he has to ask you to add that information
-each time."))
+each time.")
+  (set-x :homepage
+         "Enter the homepage URL of this library."))
 
 (defmenu (add-local-dependency :in create-project)
   (q "Enter a name of a library. The input string is converted to a keyword.
@@ -59,4 +61,3 @@ Example:   oSiCaT   -->  finally appears as :OSICAT")
 (defmenu (create :in create-project)
   (actually-create-project)
   (quit-menu))
-

--- a/src/create/project-local.lisp
+++ b/src/create/project-local.lisp
@@ -63,3 +63,42 @@ Example:   oSiCaT   -->  finally appears as :OSICAT")
 (defmenu (create :in create-project)
   (actually-create-project)
   (quit-menu))
+
+(defmenu (source-control :in create-project
+                         :message "Provide the source code repository.")
+  (q "Enter the the type of your versioning system together with the repository URL.
+Example:
+  git https://myhost.org/cgit/my-lib.git
+  => :source-control (:git \"https://myhost.org/cgit/my-lib.git\")
+
+If you host your library on Github or Gitlab you can use shortcuts for those services.
+Use \"github\" or \"gitlab\" as versioning system type and the URL is \"username/repository\".
+For both shortcuts the \":bug-tracker\" property will be added as well.
+Example:
+  github foo/foo
+  => :source-control (:git \"https://github.com/foo/foo.git\")
+     :bug-tracker \"https://github.com/foo/foo/issues\"
+
+The Gitlab shortcut works analogous. ")
+  (print-config-update-direction :source-control t)
+  (qif (source-control)
+       (destructuring-bind (type repo)
+           (rest (split "(.*) (.*)" source-control :with-registers-p t))
+         (match type
+           ((or "github" "gitlab")
+            (update-config-item
+             :source-control
+             (list :git
+                   (format nil "https://~A.com/~A.git" type repo))
+             t)
+            (update-config-item
+             :bug-tracker
+             (format nil "https://~A.com/~A/issues" type repo)
+             t))
+           (otherwise
+            (update-config-item
+             :source-control
+             (list (make-keyword (string-upcase type))
+                   repo)
+             t)))))
+  (up))


### PR DESCRIPTION
Hi,

first of all: Using restarts to generate a project skeleton is a really awesome idea. :+1: 

Further, I've added some menu for `defsystem` properties I often use:
1. homepage menu for `defsystem`'s `:homepage`
2. bug-tracker menu for `defystem`'s `:bug-tracker`
3. source-control menu for `defsystem`'s `:source-control`

The source-control menu provides shortcuts for Github an Gitlab to easier add details for those. 

Thanks in advance for merging :smile: 

Regards,
Sebastian
