### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/skeleton/<% @var name %>/.gitignore
+++ b/skeleton/<% @var name %>/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 *.fasl
 *.dx32fsl
 *.dx64fsl


### PR DESCRIPTION
For those working on Mac OSX it is better to have `.DS_Store` in the `.gitignore` file. 

Thanks in advance.

Regards,
Sebastian
